### PR TITLE
Parse command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,14 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +405,7 @@ dependencies = [
 name = "morseqtt"
 version = "0.1.0"
 dependencies = [
+ "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rumqtt 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1052,6 +1061,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1235,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
+"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
@@ -1305,6 +1320,7 @@ dependencies = [
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4.0"
+getopts = "0.2"
 itertools = "0.8"
+lazy_static = "1.4.0"
 tokio = "0.1.5"
 tokio-file-unix = "0.5.1"
 rumqtt = "0.30.1"

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,6 @@
 use crate::timing::Signal;
 use itertools::Itertools;
+use rumqtt::{MqttClient, QoS};
 use std::convert::TryFrom;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
@@ -7,17 +8,49 @@ use std::time::{Duration, Instant};
 use tokio::prelude::*;
 use tokio::timer::Delay;
 
-pub struct Key<A, B>
-where
-    A: FnMut() -> (),
-    B: FnMut() -> (),
-{
-    pub on: A,
-    pub off: B,
+#[allow(clippy::module_name_repetitions)]
+pub struct MqttKey {
+    client: MqttClient,
+    topic: String,
+    on_payload: String,
+    off_payload: String,
 }
 
-pub fn transmit_with_dur<A: FnMut() -> (), B: FnMut() -> ()>(
-    key: Arc<Mutex<Key<A, B>>>,
+impl MqttKey {
+    pub fn new(client: MqttClient, topic: String, on_payload: String, off_payload: String) -> Self {
+        Self {
+            client,
+            topic,
+            on_payload,
+            off_payload,
+        }
+    }
+
+    fn send_on(&mut self) {
+        self.client
+            .publish(
+                self.topic.as_str(),
+                QoS::AtLeastOnce,
+                false,
+                self.on_payload.as_str(),
+            )
+            .unwrap();
+    }
+
+    fn send_off(&mut self) {
+        self.client
+            .publish(
+                self.topic.as_str(),
+                QoS::AtLeastOnce,
+                false,
+                self.off_payload.as_str(),
+            )
+            .unwrap();
+    }
+}
+
+pub fn transmit_with_dur(
+    key: Arc<Mutex<MqttKey>>,
     timing: impl Iterator<Item = Signal>,
     dur: Duration,
 ) -> impl Future<Item = (), Error = ()> {
@@ -37,15 +70,15 @@ pub fn transmit_with_dur<A: FnMut() -> (), B: FnMut() -> ()>(
     stream::iter_ok(groups.into_iter())
         .for_each(move |(k, signal, count)| {
             if signal == Signal::On {
-                (k.lock().unwrap().deref_mut().on)();
+                k.lock().unwrap().deref_mut().send_on();
             } else {
-                (k.lock().unwrap().deref_mut().off)();
+                k.lock().unwrap().deref_mut().send_off();
             }
 
             Delay::new(Instant::now() + count * dur)
         })
         .and_then(move |_| {
-            (key.lock().unwrap().deref_mut().off)();
+            key.lock().unwrap().deref_mut().send_off();
             future::ok(())
         })
         .map_err(|_| ())

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,14 @@ fn main() {
         .unwrap_or_else(|| default_host!().to_string());
     let port = matches
         .opt_str("port")
-        .map_or_else(|| default_port!(), |s| s.parse::<u16>().unwrap());
+        .map_or_else(|| Ok(default_port!()), |s| s.parse::<u16>());
+    let port = match port {
+        Ok(p) => p,
+        Err(e) => {
+            println!("Error parsing 'port': {}", e);
+            return;
+        }
+    };
     let duration = Duration::from_millis(
         matches
             .opt_str("duration")
@@ -107,7 +114,13 @@ fn main() {
     let topic = matches.free.pop().unwrap();
 
     let mqtt_options = MqttOptions::new(CLIENT_NAME, &host, port);
-    let (client, _) = MqttClient::start(mqtt_options).unwrap();
+    let client = match MqttClient::start(mqtt_options) {
+        Ok((client, _)) => client,
+        Err(e) => {
+            println!("Error connecting to MQTT broker: {}", e);
+            return;
+        }
+    };
     println!("Connected to {}:{} as {}", host, port, CLIENT_NAME);
 
     // Create a Key for transmission.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,115 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::prelude::*;
 
-const DOT_DURATION: Duration = Duration::from_millis(50);
 const CLIENT_NAME: &str = "morseqtt";
 
-fn main() {
-    let host = "localhost";
-    let port = 1883;
+// concat!() doesn't accept const variables so we define a macro so the values aren't written twice.
+macro_rules! default_host {
+    () => {
+        "localhost"
+    };
+}
+macro_rules! default_port {
+    () => {
+        1883
+    };
+}
+macro_rules! default_duration_ms {
+    () => {
+        50
+    };
+}
 
-    let mqtt_options = MqttOptions::new(CLIENT_NAME, host, port);
+fn program_opts() -> getopts::Options {
+    let mut opts = getopts::Options::new();
+
+    opts.optopt(
+        "h",
+        "host",
+        concat!("mqtt host to connect to. [", default_host!(), "]"),
+        "<host>",
+    );
+    opts.optopt(
+        "p",
+        "port",
+        concat!("network port to connect to. [", default_port!(), "]"),
+        "<port>",
+    );
+    opts.optopt(
+        "d",
+        "duration",
+        concat!(
+            "morse code dot duration, in milliseconds. [",
+            default_duration_ms!(),
+            "]"
+        ),
+        "<milliseconds>",
+    );
+    opts.optflag("", "help", "print this help menu");
+
+    opts
+}
+
+fn print_usage(program: &str, opts: getopts::Options) {
+    let brief = format!(
+        concat!(
+            "Usage: {} [options] <topic> <on_payload> <off_payload>\n\n",
+            "Translate input to morse code and send using MQTT."
+        ),
+        program
+    );
+    print!("{}", opts.usage(&brief));
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = program_opts();
+    let mut matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => {
+            println!("{}", f.to_string());
+            println!();
+            print_usage(&program, opts);
+            return;
+        }
+    };
+    if matches.opt_present("help") {
+        print_usage(&program, opts);
+        return;
+    }
+    if matches.free.len() != 3 {
+        print_usage(&program, opts);
+        return;
+    }
+
+    let host = matches
+        .opt_str("host")
+        .unwrap_or(default_host!().to_string());
+    let port = matches
+        .opt_str("port")
+        .map(|s| s.parse::<u16>().unwrap())
+        .unwrap_or(default_port!());
+    let duration = Duration::from_millis(
+        matches
+            .opt_str("duration")
+            .map(|s| s.parse::<u64>().unwrap())
+            .unwrap_or(default_duration_ms!()),
+    );
+    let off_payload = matches.free[0].as_str();
+    let on_payload = matches.free[1].as_str();
+    let topic = matches.free[2].as_str();
+    println!("topic: {}", topic);
+    println!("on payload: {}", on_payload);
+    println!("off payload: {}", off_payload);
+    println!("duration: {:?}", duration);
+    println!("host: {}", host);
+    println!("port: {}", port);
+
+    let mqtt_options = MqttOptions::new(CLIENT_NAME, &host, port);
     let (mut client1, _) = MqttClient::start(mqtt_options).unwrap();
     let mut client2 = client1.clone();
-
     println!("Connected to {}:{} as {}", host, port, CLIENT_NAME);
 
     // Create a Key for transmission.
@@ -56,7 +154,7 @@ fn main() {
             transmit_with_dur(
                 Arc::clone(&k),
                 Code::from_str(s).unwrap().into_timing(),
-                DOT_DURATION,
+                duration,
             )
             .and_then(|_| {
                 println!("Transmission complete.");


### PR DESCRIPTION
Add arguments to set mqtt broker host and port, publisher topic, on/off
payloads, and morse code dot duration. Topic and payload arguments are
not yet used.

This commit adds getopts as a dependency.